### PR TITLE
Quote curl response

### DIFF
--- a/glob.sh
+++ b/glob.sh
@@ -26,7 +26,7 @@ while IFS= read -r -d '' file; do
   CMD="$CMD -F \"file=@$file;filename=$REL_PATH;type=$MIME_TYPE\""
 done < <(find "$DIR" -type f -print0)
 
-RESPONSE=$(eval $CMD)
+RESPONSE="$(eval $CMD)"
 
 mv ./zod/.urb/put/*.glob .
 rm -rf zod


### PR DESCRIPTION
The glob script is failing for a few files. In particular the Inter font file is losing it's last byte. Upon inspection, the last byte is a zero byte. This could be due to the response call not being quoted. This quotes the response call.